### PR TITLE
(GH-291) Hugo docs initialisation

### DIFF
--- a/docs/md/content/CHANGELOG.md
+++ b/docs/md/content/CHANGELOG.md
@@ -1,0 +1,15 @@
+---
+title: "Changelog"
+draft: false
+---
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[Unreleased]: https://github.com/puppetlabs/prm/compare/9d7ff6acd89f19cd24492acc9058c4c5752bcbe5..main

--- a/docs/md/content/CONTRIBUTING.md
+++ b/docs/md/content/CONTRIBUTING.md
@@ -1,0 +1,106 @@
+---
+title: "Contributing"
+draft: false
+---
+
+# Contributing
+
+Hi! Thanks for your interest in contributing to the Puppet Development Kit!
+
+Community contributions are essential for keeping Puppet great.
+We simply can't access the huge number of platforms and myriad configurations for running Puppet.
+We want to keep it as easy as possible to contribute changes that get things working in your environment.
+There are a few guidelines that we need contributors to follow so that we can have a chance of keeping on top of things.
+
+We accept pull requests for bug fixes and features where we've discussed the approach in an issue and given the go-ahead for a community member to work on it.
+We'd also love to hear about ideas for new features as Github Discussion.
+
+Please do:
+
+- Open an issue if things aren't working as expected.
+- Open a Github Discussion to propose a significant change.
+- Open a pull request to fix a bug.
+- Open a pull request to fix documentation about a command.
+- Open a pull request for any issue labelled help wanted or good first issue.
+
+## Building the project
+
+Prerequisites:
+
+- Go 1.16+
+
+To build PRM, run the following command:
+
+> These build scripts produce a binary for the current platform only.
+> These scripts are meant for local testing.
+> We use a Github Action to release this product.
+
+```bash
+> # on nix
+> ./build.sh
+```
+
+```powershell
+# on windows
+> ./build.ps1
+```
+
+To run the new binary:
+
+```bash
+> ./prm [command]
+```
+
+To test the PRM command, run the following command:
+
+```bash
+> go test ./...
+```
+
+To run the acceptance tests, ensure that you have built the PRM binary using the build scripts, then:
+
+```bash
+TEST_ACCEPTANCE=true go test -count=1 -v github.com/puppetlabs/prm/acceptance
+```
+
+## Running the project
+
+```bash
+> go run main.go
+```
+
+## Building Cross Platform binaries
+
+Prerequisites:
+
+- Go 1.16+
+- goreleaser 0.16+
+
+To build the PRM for more than your current platform, use [`GoReleaser`](https://goreleaser.com/quick-start/#dry-run):
+
+```bash
+> goreleaser --snapshot --skip-publish --rm-dist
+```
+
+This will ouput a set of binaries in the `dist` folder.
+
+## Submitting a Pull Request
+
+1. Create a new branch `git checkout -b my-branch-name`
+1. Make you change, add tests, and ensure tests pass
+1. Make sure your commit messages are in the proper format.
+   If the commit addresses an issue filed in the project, start the first line of the commit with the prefix `GH-` and the issue number in parentheses `(GH-111)`.
+   After leave a detailed explanation of your change, so a person in the future can understand what your work does.
+1. Submit a pull request (i.e. using the Github commandline: `gh pr create --web`)
+
+## Making Trivial Changes
+
+For changes of a trivial nature, it is not always necessary to create a new ticket.
+In this case, it is appropriate to start the first line of a commit with one of (docs), (maint), or (packaging) instead of a ticket number.
+
+## Additional Resources
+
+- [Puppet community guidelines](https://puppet.com/community/community-guidelines)
+- [Contributor License Agreement](http://cla.puppet.com/)
+- [General GitHub documentation](https://help.github.com/)
+- [GitHub pull request documentation](https://help.github.com/articles/creating-a-pull-request/)

--- a/docs/md/content/README.md
+++ b/docs/md/content/README.md
@@ -1,0 +1,92 @@
+---
+title: "Readme"
+draft: false
+---
+
+# Puppet Runtime Manager
+
+- [Puppet Runtime Manager](#puppet-runtime-manager)
+  - [Overview](#overview)
+  - [Installing](#installing)
+    - [Unix Systems](#unix-systems)
+    - [Windows Systems](#windows-systems)
+  - [Requesting a feature](#requesting-a-feature)
+  - [Reporting Problems](#reporting-problems)
+  - [Installing Telemetry Free Version](#installing-telemetry-free-version)
+    - [Unix Systems](#unix-systems-1)
+    - [Windows Systems](#windows-systems-1)
+
+## Overview
+
+The Puppet Runtime Manager (PRM) is a tool for validating Puppet content and for running arbitrary development/maintenance tasks against that content.
+
+> :warning: PRM is currently in an EXPERIMENTAL phase and feedback is encouraged via [prm/discussions](https://github.com/puppetlabs/prm/discussions) and starting a `feedback` post.
+
+## Installing
+
+While PRM is in early release, we provide an archive and a simple script to unpack it.
+When we move closer to a full release we will add a platform specific installer.
+Use the `install.[ps1|sh]` script, depending upon your OS:
+
+### Unix Systems
+
+```bash
+curl -L https://pup.pt/prm/install.sh | sh
+```
+
+### Windows Systems
+
+```ps
+iex "&{ $(irm https://pup.pt/prm/install.ps1); Install-Prm }"
+```
+
+This will install the latest release of PRM to `~/.puppetlabs/prm`.
+
+<!-- This gif needs to be created once the scripts are callable -->
+<!-- ![install_prm](docs/_resources/install_and_export_path.gif) -->
+
+> :warning: If you do not use the install script and are extracting the archive yourself, be sure to use the fully qualified path to `~/.puppetlabs/prm` on *nix or `$HOME/.puppetlabs/prm` on Windows when you set your `PATH` environment variable.
+
+A version of the product, with telemetry functionality disabled, is available too.
+See [here](#installing-telemetry-free-version) for instructions on how to install it.
+
+## Requesting a feature
+
+Open a new feature request in our [Github discussion](https://github.com/puppetlabs/prm/discussions/new) page.
+
+## Reporting Problems
+
+If you're having trouble with the experimental PRM tool, please follow these instructions
+to file an issue on our GitHub repository: https://github.com/puppetlabs/prm/issues/new
+
+Make sure to fill in the information that is requested in the issue template as it
+will help us investigate the problem more quickly.
+
+## Installing Telemetry Free Version
+
+We gather telemetry data to provide insights into how our products are being used.
+
+The following data is collected:
+
+- Version of application in use
+- OS / platform of the device
+- What commands have been invoked (including command args)
+- Any errors that occurred when running the application
+
+We understand that there will be some users who prefer to have no telemetry data sent.
+For those users, we offer a version of PRM with the telemetry functionality disabled.
+
+To install:
+### Unix Systems
+
+```bash
+curl -L https://pup.pt/prm/install.sh | sh -s -- --no-telemetry
+```
+
+### Windows Systems
+
+```ps
+iex "&{ $(irm https://pup.pt/prm/install.ps1); Install-Prm -NoTelemetry }"
+```
+
+This will install the latest release of PRM, without telemetry functionality, to `~/.puppetlabs/prm`.

--- a/docs/md/go.mod
+++ b/docs/md/go.mod
@@ -1,0 +1,3 @@
+module github.com/puppetlabs/prm/docs/md
+
+go 1.17


### PR DESCRIPTION
Overview of PR:

- Added a hugo module to the `docs/md` directory which can then be mounted
onto the documentation website.
- Also copied the README, CHANGELOG and CONTRIBUTING markdown files to the
`docs/md` directory and added frontmatter to those files.