### PR TITLE
(GH-9) Add EPP validator tool example

### DIFF
--- a/examples/tools/epp/Dockerfile
+++ b/examples/tools/epp/Dockerfile
@@ -1,0 +1,21 @@
+# based upon the work in https://github.com/da-ar/pcv-test/
+# this file is a mock up of what a generated file based on the prm-config.yml
+# would have to contain in order to work.
+
+# build with:
+# docker build -t pdk:puppet-7.11.0-epp -f examples/tools/epp/Dockerfile .
+
+# run with:
+# docker run -v ${PWD}:/module -w /module pdk:puppet-7.11.0-epp
+
+FROM puppet/puppet-agent:5.5.0
+VOLUME [ "/code" ]
+# The working directory must be where the code lives
+WORKDIR /code
+
+COPY ./content/* /tmp/
+
+# use_entrypoint_script: true
+ENTRYPOINT [ "/tmp/entrypoint.sh" ]
+# default_args is empty, do not write CMD
+# CMD []

--- a/examples/tools/epp/content/entrypoint.ps1
+++ b/examples/tools/epp/content/entrypoint.ps1
@@ -1,0 +1,14 @@
+$Files = If ([string]::IsNullOrEmpty($args)) {
+  Get-ChildItem -Recurse -File -Filter '*.epp'
+} ElseIf ($args[0].ToString() -eq 'help') {
+  "Please specify a filter pattern to search for EPP files, such as '*.epp'"
+  return
+} Else {
+  $args | ForEach-Object {
+    Get-ChildItem -Recurse -File -Filter $_
+  }
+}
+$Files = $Files.FullName
+
+"Validating EPP for ${files}"
+& puppet epp validate --continue_on_error $Files

--- a/examples/tools/epp/content/entrypoint.sh
+++ b/examples/tools/epp/content/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+if [ -z "$1" ]
+then
+  files=$(find . -type f -name '*.epp')
+elif [ "$1" = "help" ]
+then
+  echo "Please specify a file glob pattern to search for EPP files, such as '**/*.epp'"
+  exit
+else
+  cmd="find ."
+  for var in "$@"
+  do
+    cmd="$cmd -o -type f -name '$var'"
+  done
+  cmd=$(echo "$cmd" | sed '0,/-o/s///')
+  files=$(eval ${cmd})
+fi
+echo "Validating EPP for ${files}"
+puppet epp validate --continue_on_error $files

--- a/examples/tools/epp/prm-config.yml
+++ b/examples/tools/epp/prm-config.yml
@@ -1,0 +1,19 @@
+---
+plugin:
+  author: puppetlabs
+  id: epp
+  display: Embedded Puppet (EPP)
+  version: 0.1.0
+  upstream_project_url: https://puppet.com/docs/puppet/7/lang_template_epp.html
+
+puppet: true
+
+common:
+  can_validate: true
+  needs_write_access: false
+  use_script: 'entrypoint'
+  # No longer necessary as default args are handled in the scripts
+  # default_args: []
+  help_arg: 'help' # 🤔 Will have to noodle on this for scripts
+  success_exit_code: 0
+  interleave_stdout_err: false


### PR DESCRIPTION
This commit adds the prm-config.yml for validating any embedded puppet files in a folder. It includes a working example of the Dockerfile that would be generated via PRM to implement this plugin.

This has been manually validated against the MOTD module, passing and returning an exit code of 0.

- Resolves #9 