### PR TITLE
(GH-15) Implement `prm set|get backend`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -72,6 +72,29 @@
         "get",
         "puppet",
       ],
+    },
+    {
+      "name": "Debug (With Telemetry): prm get backend",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}",
+      "args": [
+        "get",
+        "backend",
+      ],
+      "buildFlags": "-tags='telemetry' -ldflags='-X main.honeycomb_api_key=${input:honeycomb_api_key} -X main.honeycomb_dataset=pct_dev'",
+    },
+    {
+      "name": "Debug (No Telemetry): prm get backend",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}",
+      "args": [
+        "get",
+        "backend",
+      ],
     }
   ],
   "inputs": [

--- a/cmd/get/backend.go
+++ b/cmd/get/backend.go
@@ -1,0 +1,22 @@
+package get
+
+import (
+	"github.com/puppetlabs/prm/pkg/prm"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+func createGetBackendCommand() *cobra.Command {
+	tmp := &cobra.Command{
+		Use:   "backend",
+		Short: "Gets the Backend version currently configured",
+		Long:  "Gets the Backend version currently configured",
+		Run:   getBackend,
+	}
+
+	return tmp
+}
+
+func getBackend(cmd *cobra.Command, args []string) {
+	log.Info().Msgf("Backend is configured to: %s", prm.RunningConfig.Backend)
+}

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -9,16 +9,17 @@ import (
 
 func CreateGetCommand() *cobra.Command {
 	tmp := &cobra.Command{
-		Use:                   fmt.Sprintf("get %s", prm.PuppetCmdFlag),
+		Use:                   fmt.Sprintf("get <%s|%s>", prm.BackendCmdFlag, prm.PuppetCmdFlag),
 		Short:                 "Displays the requested configuration value",
 		Long:                  "Displays the requested configuration value",
 		DisableFlagsInUseLine: true,
-		ValidArgs:             []string{prm.PuppetCmdFlag},
+		ValidArgs:             []string{prm.BackendCmdFlag, prm.PuppetCmdFlag},
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.HelpFunc()(cmd, args)
 		},
 	}
 	tmp.AddCommand(createGetPuppetCommand())
+	tmp.AddCommand(createGetBackendCommand())
 
 	return tmp
 }

--- a/cmd/get/get_test.go
+++ b/cmd/get/get_test.go
@@ -24,12 +24,6 @@ func Test_GetCommand(t *testing.T) {
 			expectedOutput: "Displays the requested configuration value",
 			expectError:    true,
 		},
-	}
-	execTests(t, tests)
-}
-
-func Test_GetPuppetCommand(t *testing.T) {
-	tests := []test{
 		{
 			name:           "Should display help when invalid subcommand passed to 'get'",
 			args:           []string{"foo"},

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -74,10 +74,20 @@ func InitConfig() {
 		viper.SetConfigFile(cfgFile)
 	} else {
 		home, _ := homedir.Dir()
-		viper.SetConfigName(".prm")
+		cfgFile = ".prm.yaml"
+		viper.SetConfigName(cfgFile)
 		viper.SetConfigType("yaml")
 		viper.AddConfigPath(home)
-		viper.AddConfigPath(filepath.Join(home, ".config"))
+		cfgPath := filepath.Join(home, ".config")
+		viper.AddConfigPath(cfgPath)
+
+		cfgFilePath := filepath.Join(cfgPath, cfgFile)
+		_, err := os.Stat(cfgFilePath)
+		if os.IsNotExist(err) {
+			if _, err := os.Create(cfgFilePath); err != nil {
+				log.Error().Msgf("failed to initialise %s: %s", cfgFilePath, err)
+			}
+		}
 	}
 
 	viper.AutomaticEnv()

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -96,6 +96,8 @@ func InitConfig() {
 		log.Trace().Msgf("Using config file: %s", viper.ConfigFileUsed())
 	}
 
+	prm.GenerateDefaultCfg()
+
 	if err := prm.LoadConfig(); err != nil {
 		log.Warn().Msgf("Error setting running config: %s", err)
 	}

--- a/cmd/set/backend.go
+++ b/cmd/set/backend.go
@@ -1,0 +1,47 @@
+package set
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/puppetlabs/prm/pkg/prm"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var SelectedBackend prm.BackendType
+
+func createSetBackendCommand() *cobra.Command {
+	tmp := &cobra.Command{
+		Use:     "backend <BACKEND>",
+		Short:   "Sets the backend exec environment to the specified type",
+		Long:    `Sets the backend exec environment to the specified type`,
+		PreRunE: setBackendPreRunE,
+		Run:     setBackendType,
+	}
+
+	return tmp
+}
+
+func setBackendPreRunE(cmd *cobra.Command, args []string) (err error) {
+	if len(args) > 1 {
+		return fmt.Errorf("too many args, please specify ONE of the following backend types after 'set backend':\n- %s", prm.DOCKER)
+	}
+
+	if len(args) < 1 {
+		return fmt.Errorf("please specify specify one of the following backend types after 'set backend':\n- %s", prm.DOCKER)
+	}
+
+	switch strings.ToLower(args[0]) {
+	case string(prm.DOCKER):
+		SelectedBackend = prm.DOCKER
+	default:
+		return fmt.Errorf("'%s' is not a valid backend type, please specify one of the following backend types:\n- %s", args[0], prm.DOCKER)
+	}
+
+	return nil
+}
+
+func setBackendType(cmd *cobra.Command, args []string) {
+	viper.Set(prm.BackendCfgKey, SelectedBackend)
+}

--- a/cmd/set/backend.go
+++ b/cmd/set/backend.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/puppetlabs/prm/pkg/prm"
+	"github.com/puppetlabs/prm/pkg/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -44,4 +45,5 @@ func setBackendPreRunE(cmd *cobra.Command, args []string) (err error) {
 
 func setBackendType(cmd *cobra.Command, args []string) {
 	viper.Set(prm.BackendCfgKey, SelectedBackend)
+	utils.WriteConfig()
 }

--- a/cmd/set/puppet.go
+++ b/cmd/set/puppet.go
@@ -5,11 +5,10 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/puppetlabs/prm/pkg/prm"
+	"github.com/puppetlabs/prm/pkg/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
-
-var PuppetSemVer *semver.Version
 
 func createSetPuppetCommand() *cobra.Command {
 	tmp := &cobra.Command{
@@ -22,7 +21,7 @@ func createSetPuppetCommand() *cobra.Command {
 	return tmp
 }
 
-func setPuppetVersion(cmd *cobra.Command, args []string) (err error) {
+func setPuppetVersion(cmd *cobra.Command, args []string) error {
 	if len(args) > 1 {
 		return fmt.Errorf("only a single Puppet version can be set")
 	}
@@ -31,12 +30,13 @@ func setPuppetVersion(cmd *cobra.Command, args []string) (err error) {
 		return fmt.Errorf("please specify a Puppet version after 'set puppet'")
 	}
 
-	PuppetSemVer, err = semver.NewVersion(args[0])
+	puppetSemVer, err := semver.NewVersion(args[0])
 	if err != nil {
 		return fmt.Errorf("'%s' is not a semantic (x.y.z) Puppet version: %s", args[0], err)
 	}
 
-	viper.Set(prm.PuppetVerCfgKey, PuppetSemVer.String)
+	viper.Set(prm.PuppetVerCfgKey, puppetSemVer.String())
+	utils.WriteConfig()
 
 	return err
 }

--- a/cmd/set/set.go
+++ b/cmd/set/set.go
@@ -9,10 +9,12 @@ import (
 
 func CreateSetCommand() *cobra.Command {
 	tmp := &cobra.Command{
+		// TODO: Add Backend as valid arg
 		Use:                   fmt.Sprintf("set %s", prm.PuppetCmdFlag),
 		Short:                 "Sets the specified configuration to the specified value",
 		Long:                  "Sets the specified configuration to the specified value",
 		DisableFlagsInUseLine: true,
+		// TODO: Add Backend as valid arg		
 		ValidArgs:             []string{prm.PuppetCmdFlag},
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.HelpFunc()(cmd, args)
@@ -20,6 +22,7 @@ func CreateSetCommand() *cobra.Command {
 	}
 
 	tmp.AddCommand(createSetPuppetCommand())
+	tmp.AddCommand(createSetBackendCommand())
 
 	return tmp
 }

--- a/cmd/set/set.go
+++ b/cmd/set/set.go
@@ -9,13 +9,11 @@ import (
 
 func CreateSetCommand() *cobra.Command {
 	tmp := &cobra.Command{
-		// TODO: Add Backend as valid arg
-		Use:                   fmt.Sprintf("set %s", prm.PuppetCmdFlag),
+		Use:                   fmt.Sprintf("set <%s|%s> value", prm.BackendCmdFlag, prm.PuppetCmdFlag),
 		Short:                 "Sets the specified configuration to the specified value",
 		Long:                  "Sets the specified configuration to the specified value",
 		DisableFlagsInUseLine: true,
-		// TODO: Add Backend as valid arg		
-		ValidArgs:             []string{prm.PuppetCmdFlag},
+		ValidArgs:             []string{prm.BackendCmdFlag, prm.PuppetCmdFlag},
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.HelpFunc()(cmd, args)
 		},

--- a/pkg/prm/backend.go
+++ b/pkg/prm/backend.go
@@ -1,6 +1,12 @@
 //nolint:structcheck,unused
 package prm
 
+type BackendType string
+
+const (
+	DOCKER BackendType = "docker"
+)
+
 type BackendI interface {
 	GetTool(toolName string, prmConfig Config) (Tool, error)
 	Validate(tool *Tool) (ToolExitCode, error)

--- a/pkg/prm/config.go
+++ b/pkg/prm/config.go
@@ -4,40 +4,45 @@ import (
 	"fmt"
 
 	"github.com/Masterminds/semver"
-	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
 )
 
 const (
-	PuppetCmdFlag    string = "puppet"
-	PuppetVerCfgKey  string = "puppet.version"
-	DefaultPuppetVer string = "7"
-	BackendCfgKey   string = "backend.type"
+	PuppetCmdFlag   string = "puppet"
+	BackendCmdFlag  string = "backend"
+	PuppetVerCfgKey string = "puppetversion" // Should match Config struct key.
+	BackendCfgKey   string = "backend"       // Should match Config struct key.
 )
 
 type Config struct {
 	PuppetVersion *semver.Version
-	Backend       BackendI
+	Backend       BackendType
 }
 
 var RunningConfig Config
 
-func LoadConfig() error {
-	puppetVer := viper.GetString(PuppetVerCfgKey)
-
-	// Set a default Puppet version if it's unset in config
-	if puppetVer == "" {
-		log.Debug().Msgf("'%s' unset in %s, setting default value: %s", PuppetVerCfgKey, viper.GetViper().ConfigFileUsed(), DefaultPuppetVer)
-		puppetVer = DefaultPuppetVer
-	}
-
-	puppetSemVer, err := semver.NewVersion(puppetVer)
-
+func GenerateDefaultCfg() {
+	// Generate default configuration
+	puppetVer, err := semver.NewVersion("7")
 	if err != nil {
-		return fmt.Errorf("Value for '%s' in config is not a valid Puppet semver: %s", PuppetVerCfgKey, err)
+		panic(fmt.Sprintf("Unable to generate default cfg value for 'puppet': %s", err))
 	}
 
-	RunningConfig.PuppetVersion = puppetSemVer
+	viper.SetDefault(PuppetVerCfgKey, puppetVer)
+	viper.SetDefault(BackendCfgKey, DOCKER)
+}
+
+func LoadConfig() error {
+	// Load Puppet version from config
+	pupperSemVer, err := semver.NewVersion(viper.GetString(PuppetVerCfgKey))
+	if err != nil {
+		return fmt.Errorf("could not load '%s' from config '%s': %s", PuppetVerCfgKey, viper.GetViper().ConfigFileUsed(), err)
+	}
+
+	RunningConfig.PuppetVersion = pupperSemVer
+
+	// Load Backend from config
+	RunningConfig.Backend = BackendType(viper.GetString(BackendCfgKey))
 
 	return nil
 }

--- a/pkg/prm/config.go
+++ b/pkg/prm/config.go
@@ -4,14 +4,17 @@ import (
 	"fmt"
 
 	"github.com/Masterminds/semver"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
 )
 
 const (
-	PuppetCmdFlag   string = "puppet"
-	BackendCmdFlag  string = "backend"
-	PuppetVerCfgKey string = "puppetversion" // Should match Config struct key.
-	BackendCfgKey   string = "backend"       // Should match Config struct key.
+	PuppetCmdFlag    string      = "puppet"
+	BackendCmdFlag   string      = "backend"
+	PuppetVerCfgKey  string      = "puppetversion" // Should match Config struct key.
+	BackendCfgKey    string      = "backend"       // Should match Config struct key.
+	DefaultPuppetVer string      = "7"
+	DefaultBackend   BackendType = DOCKER
 )
 
 type Config struct {
@@ -23,13 +26,15 @@ var RunningConfig Config
 
 func GenerateDefaultCfg() {
 	// Generate default configuration
-	puppetVer, err := semver.NewVersion("7")
+	puppetVer, err := semver.NewVersion(DefaultPuppetVer)
 	if err != nil {
 		panic(fmt.Sprintf("Unable to generate default cfg value for 'puppet': %s", err))
 	}
 
+	log.Trace().Msgf("Setting default config (%s: %s)", PuppetVerCfgKey, puppetVer.String())
 	viper.SetDefault(PuppetVerCfgKey, puppetVer)
-	viper.SetDefault(BackendCfgKey, DOCKER)
+	log.Trace().Msgf("Setting default config (%s: %s)", BackendCfgKey, DefaultBackend)
+	viper.SetDefault(BackendCfgKey, string(DefaultBackend))
 }
 
 func LoadConfig() error {

--- a/pkg/prm/config.go
+++ b/pkg/prm/config.go
@@ -12,6 +12,7 @@ const (
 	PuppetCmdFlag    string = "puppet"
 	PuppetVerCfgKey  string = "puppet.version"
 	DefaultPuppetVer string = "7"
+	BackendCfgKey   string = "backend.type"
 )
 
 type Config struct {

--- a/pkg/prm/config_test.go
+++ b/pkg/prm/config_test.go
@@ -1,0 +1,72 @@
+package prm_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/puppetlabs/prm/pkg/prm"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateDefaultCfg(t *testing.T) {
+	tests := []struct {
+		name                  string
+		expectedPuppetVersion string
+		expectedBackend       string
+	}{
+		{
+			name:                  "Should generate default Puppet and Backend cfgs",
+			expectedPuppetVersion: "7.0.0",
+			expectedBackend:       string(prm.DOCKER),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prm.GenerateDefaultCfg()
+			assert.Equal(t, tt.expectedPuppetVersion, viper.GetString(prm.PuppetVerCfgKey))
+			assert.Equal(t, tt.expectedBackend, viper.Get(prm.BackendCfgKey))
+		})
+	}
+}
+
+// To test unlikely error condition that a garbage or nil version has made it
+// in as the configured Puppet version
+func TestLoadConfig(t *testing.T) {
+	tests := []struct {
+		name                string
+		expectedErrMsg      string
+		configuredPuppetVer string
+	}{
+		{
+			name:           "Should error when nil returned for Puppet ver",
+			expectedErrMsg: fmt.Sprintf("could not load '%s' from config '%s': Invalid Semantic Version", prm.PuppetVerCfgKey, viper.GetViper().ConfigFileUsed()),
+		},
+		{
+			name:                "Should error when invalid semver returned for Puppet ver",
+			expectedErrMsg:      fmt.Sprintf("could not load '%s' from config '%s': Invalid Semantic Version", prm.PuppetVerCfgKey, viper.GetViper().ConfigFileUsed()),
+			configuredPuppetVer: "foo.bar",
+		},
+		{
+			name:                "Should not error when valid semver returned for Puppet ver",
+			configuredPuppetVer: "7.0.0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.SetDefault(prm.PuppetVerCfgKey, tt.configuredPuppetVer)
+
+			err := prm.LoadConfig()
+
+			if tt.expectedErrMsg != "" && err != nil {
+				assert.Contains(t, tt.expectedErrMsg, err.Error())
+				return
+			}
+
+			if tt.expectedErrMsg == "" && err != nil {
+				t.Errorf("LoadConfig() Unexpected error: %s", err)
+				return
+			}
+		})
+	}
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,12 @@
+package utils
+
+import (
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/viper"
+)
+
+func WriteConfig() {
+	if err := viper.WriteConfig(); err != nil {
+		log.Error().Msgf("could not write config to %s: %s", viper.ConfigFileUsed(), err)
+	}
+}


### PR DESCRIPTION
This PR is made up of multiple commits that:

- Implement the `prm set backend` command
- Fixes an issue with the `.prm.yml` not being instantiated by Viper (#30)
- Generates sensible default values for the Puppet Runtime and Backend, if not set

The `prm get` commands will need more thorough test coverage, which has been ticketed: #28 

Resolves: #15 , #30 