### PR TITLE
(GH-36) Fix NPE when puppet version unset in cfg on disk

### DIFF
--- a/pkg/prm/config.go
+++ b/pkg/prm/config.go
@@ -49,8 +49,13 @@ func GenerateDefaultCfg() {
 }
 
 func LoadConfig() error {
-	// Load Puppet version from config
-	pupperSemVer, err := semver.NewVersion(viper.GetString(PuppetVerCfgKey))
+	// If the scenario where any other config value has been set AND the Puppet version is unset, a '{}' is written
+	// to the config file on disk. This causes issues when attempting to call semver.NewVersion.
+	puppetVer := viper.GetString(PuppetVerCfgKey)
+	if puppetVer == "" {
+		puppetVer = DefaultPuppetVer
+	}
+	pupperSemVer, err := semver.NewVersion(puppetVer)
 	if err != nil {
 		return fmt.Errorf("could not load '%s' from config '%s': %s", PuppetVerCfgKey, viper.GetViper().ConfigFileUsed(), err)
 	}


### PR DESCRIPTION
Prior to this commit, if a config value is being set
(e.g.` prm set backend`), but the Puppet version is still unset
and using the viper default value, when the config is being written,
viper still sees an empty `semver.Version` as a non-empty value
and writes it to config as:

```yaml
puppetversion: {}
```

This causes an NPE when the `.String()` method is called on
`prm.RunningConfig.PuppetVersion`.

This commit adds a check when we load the puppet ver config value
from Viper and assigns the default puppet version if the string
returned is empty.

Resolves: #36 