### PR TITLE
(GH-14) Initial status implementation

### DIFF
--- a/acceptance/status/status_test.go
+++ b/acceptance/status/status_test.go
@@ -1,0 +1,48 @@
+package status_test
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/puppetlabs/pdkgo/acceptance/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+const APP = "prm"
+
+func Test_PrmStatus_NoArgs(t *testing.T) {
+	testutils.SkipAcceptanceTest(t)
+	if runtime.GOOS == "darwin" {
+		t.Skip("Docker based acceptance tests currently fail on MacOS")
+	}
+
+	// Setup
+	testutils.SetAppName(APP)
+
+	// Exec
+	stdout, stderr, exitCode := testutils.RunAppCommand("status", "")
+
+	assert.Contains(t, stdout, "Puppet version: 7.0.0")
+	assert.Contains(t, stdout, "Backend: docker (running)")
+	assert.Empty(t, stderr)
+	assert.Equal(t, 0, exitCode)
+}
+
+func Test_PrmStatus_Json(t *testing.T) {
+	testutils.SkipAcceptanceTest(t)
+	if runtime.GOOS == "darwin" {
+		t.Skip("Docker based acceptance tests currently fail on MacOS")
+	}
+
+	// Setup
+	testutils.SetAppName(APP)
+
+	// Exec
+	stdout, stderr, exitCode := testutils.RunAppCommand("status --format json", "")
+
+	assert.Contains(t, stdout, `"PuppetVersion":"7.0.0"`)
+	assert.Contains(t, stdout, `"Backend":"docker"`)
+	assert.Contains(t, stdout, `"IsAvailable":true`)
+	assert.Empty(t, stderr)
+	assert.Equal(t, 0, exitCode)
+}

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -1,0 +1,52 @@
+package status
+
+import (
+	"fmt"
+
+	"github.com/puppetlabs/prm/pkg/prm"
+	"github.com/spf13/cobra"
+)
+
+var (
+	format string
+	prmApi *prm.Prm
+)
+
+func CreateStatusCommand(parent *prm.Prm) *cobra.Command {
+	prmApi = parent
+
+	tmp := &cobra.Command{
+		Use:     "status",
+		Short:   "Returns runtime status",
+		Long:    "Returns the status of the puppet manager runtime as currently configured, including both puppet version and backend",
+		PreRunE: preExecute,
+		RunE:    execute,
+	}
+
+	tmp.Flags().SortFlags = false
+	tmp.Flags().StringVarP(&format, "format", "f", "human", "display output in human or json format")
+	err := tmp.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"human", "json"}, cobra.ShellCompDirectiveNoFileComp
+	})
+	cobra.CheckErr(err)
+
+	return tmp
+}
+
+func preExecute(cmd *cobra.Command, args []string) error {
+	switch prmApi.RunningConfig.Backend {
+	default:
+		prmApi.Backend = &prm.Docker{}
+	}
+	return nil
+}
+
+func execute(cmd *cobra.Command, args []string) error {
+	status, err := prm.FormatStatus(prmApi.GetStatus(), format)
+	if err != nil {
+		return err
+	}
+	fmt.Print(status)
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -26,10 +26,10 @@ require (
 	github.com/spf13/viper v1.9.0
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/proto/otlp v0.11.0 // indirect
-	golang.org/x/net v0.0.0-20211201190559-0a0e4e1bb54c // indirect
-	golang.org/x/sys v0.0.0-20211124211545-fe61309f8881 // indirect
+	golang.org/x/net v0.0.0-20211205041911-012df41ee64c // indirect
+	golang.org/x/sys v0.0.0-20211205182925-97ca703d548d // indirect
 	golang.org/x/text v0.3.7 // indirect
-	google.golang.org/genproto v0.0.0-20211129164237-f09f9a12af12 // indirect
+	google.golang.org/genproto v0.0.0-20211203200212-54befc351ae9 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -906,8 +906,8 @@ golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLd
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211201190559-0a0e4e1bb54c h1:WtYZ93XtWSO5KlOMgPZu7hXY9WhMZpprvlm5VwvAl8c=
-golang.org/x/net v0.0.0-20211201190559-0a0e4e1bb54c/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211205041911-012df41ee64c h1:7SfqwP5fxEtl/P02w5IhKc86ziJ+A25yFrkVgoy2FT8=
+golang.org/x/net v0.0.0-20211205041911-012df41ee64c/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -1028,8 +1028,8 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211124211545-fe61309f8881 h1:TyHqChC80pFkXWraUUf6RuB5IqFdQieMLwwCJokV2pc=
-golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211205182925-97ca703d548d h1:FjkYO/PPp4Wi0EAUOVLxePm7qVW4r4ctbWpURyuOD0E=
+golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1205,8 +1205,8 @@ google.golang.org/genproto v0.0.0-20210805201207-89edb61ffb67/go.mod h1:ob2IJxKr
 google.golang.org/genproto v0.0.0-20210813162853-db860fec028c/go.mod h1:cFeNkxwySK631ADgubI+/XFU/xp8FD5KIVV4rj8UC5w=
 google.golang.org/genproto v0.0.0-20210821163610-241b8fcbd6c8/go.mod h1:eFjDcFEctNawg4eG61bRv87N7iHBWyVhJu7u1kqDUXY=
 google.golang.org/genproto v0.0.0-20210828152312-66f60bf46e71/go.mod h1:eFjDcFEctNawg4eG61bRv87N7iHBWyVhJu7u1kqDUXY=
-google.golang.org/genproto v0.0.0-20211129164237-f09f9a12af12 h1:DN5b3HU13J4sMd/QjDx34U6afpaexKTDdop+26pdjdk=
-google.golang.org/genproto v0.0.0-20211129164237-f09f9a12af12/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
+google.golang.org/genproto v0.0.0-20211203200212-54befc351ae9 h1:fU3FNfL/oBU2D5DvGqiuyVqqn40DdxvaTFHq7aivA3k=
+google.golang.org/genproto v0.0.0-20211203200212-54befc351ae9/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=

--- a/internal/pkg/mock/backend.go
+++ b/internal/pkg/mock/backend.go
@@ -1,0 +1,29 @@
+package mock
+
+import (
+	"github.com/puppetlabs/prm/pkg/prm"
+)
+
+type MockBackend struct {
+	StatusIsAvailable   bool
+	StatusMessageString string
+}
+
+func (m *MockBackend) Status() prm.BackendStatus {
+	return prm.BackendStatus{IsAvailable: m.StatusIsAvailable, StatusMsg: m.StatusMessageString}
+}
+
+// Implement when needed
+func (m *MockBackend) GetTool(toolName string, prmConfig prm.Config) (prm.Tool, error) {
+	return prm.Tool{}, nil
+}
+
+// Implement when needed
+func (m *MockBackend) Validate(tool *prm.Tool) (prm.ToolExitCode, error) {
+	return prm.FAILURE, nil
+}
+
+// Implement when needed
+func (m *MockBackend) Exec(tool *prm.Tool, args []string) (prm.ToolExitCode, error) {
+	return prm.FAILURE, nil
+}

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/puppetlabs/prm/cmd/get"
 	"github.com/puppetlabs/prm/cmd/root"
 	"github.com/puppetlabs/prm/cmd/set"
+	"github.com/puppetlabs/prm/cmd/status"
 	appver "github.com/puppetlabs/prm/cmd/version"
 	"github.com/puppetlabs/prm/pkg/prm"
 	"github.com/puppetlabs/prm/pkg/utils"
@@ -59,6 +60,9 @@ func main() {
 
 	// exec command
 	rootCmd.AddCommand(exec.CreateCommand(prmApi))
+
+	// status command
+	rootCmd.AddCommand(status.CreateStatusCommand(prmApi))
 
 	// initialize
 	cobra.OnInitialize(root.InitLogger, root.InitConfig)

--- a/pkg/prm/backend.go
+++ b/pkg/prm/backend.go
@@ -11,6 +11,7 @@ type BackendI interface {
 	GetTool(toolName string, prmConfig Config) (Tool, error)
 	Validate(tool *Tool) (ToolExitCode, error)
 	Exec(tool *Tool, args []string) (ToolExitCode, error)
+	Status() BackendStatus
 }
 
 // The BackendStatus must report whether the backend is available

--- a/pkg/prm/status.go
+++ b/pkg/prm/status.go
@@ -1,0 +1,43 @@
+package prm
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/semver"
+)
+
+type Status struct {
+	PuppetVersion *semver.Version
+	Backend       BackendType
+	BackendStatus BackendStatus
+}
+
+func (p *Prm) GetStatus() (status Status) {
+	status.PuppetVersion = p.RunningConfig.PuppetVersion
+	status.Backend = p.RunningConfig.Backend
+	status.BackendStatus = p.Backend.Status()
+
+	return status
+}
+
+func FormatStatus(status Status, outputType string) (statusMessage string, err error) {
+	if outputType == "json" {
+		jsonBytes, err := json.Marshal(status)
+		if err == nil {
+			statusMessage = string(jsonBytes)
+		}
+	} else {
+		var messageLines strings.Builder
+		messageLines.WriteString(fmt.Sprintf("> Puppet version: %s\n", status.PuppetVersion))
+		if status.BackendStatus.IsAvailable {
+			messageLines.WriteString(fmt.Sprintf("> Backend: %s (running)\n", status.Backend))
+		} else {
+			messageLines.WriteString(fmt.Sprintf("> Backend: %s (error)\n", status.Backend))
+			messageLines.WriteString(fmt.Sprintf("> %s\n", status.BackendStatus.StatusMsg))
+		}
+		statusMessage = messageLines.String()
+	}
+	return statusMessage, err
+}

--- a/pkg/prm/status_test.go
+++ b/pkg/prm/status_test.go
@@ -1,0 +1,150 @@
+package prm_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Masterminds/semver"
+	"github.com/puppetlabs/prm/internal/pkg/mock"
+	"github.com/puppetlabs/prm/pkg/prm"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrm_GetStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		p          *prm.Prm
+		wantStatus prm.Status
+	}{
+		{
+			name: "Returns a correct Status object",
+			p: &prm.Prm{
+				RunningConfig: prm.Config{
+					PuppetVersion: semver.MustParse("7.0.0"),
+					Backend:       prm.DOCKER,
+				},
+				Backend: &mock.MockBackend{
+					StatusIsAvailable:   true,
+					StatusMessageString: "Running just fine!",
+				},
+			},
+			wantStatus: prm.Status{
+				PuppetVersion: semver.MustParse("7.0.0"),
+				Backend:       prm.DOCKER,
+				BackendStatus: prm.BackendStatus{
+					IsAvailable: true,
+					StatusMsg:   "Running just fine!",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotStatus := tt.p.GetStatus(); !reflect.DeepEqual(gotStatus, tt.wantStatus) {
+				t.Errorf("Prm.GetStatus() = %v, want %v", gotStatus, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestFormatStatus(t *testing.T) {
+	type args struct {
+		status     prm.Status
+		outputType string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+		matches []string
+	}{
+		{
+			name: "human format running backend",
+			args: args{
+				outputType: "human",
+				status: prm.Status{
+					PuppetVersion: semver.MustParse("7.0.0"),
+					Backend:       prm.DOCKER,
+					BackendStatus: prm.BackendStatus{
+						IsAvailable: true,
+						StatusMsg:   "Running just fine",
+					},
+				},
+			},
+			matches: []string{
+				"> Puppet version: 7.0.0",
+				"> Backend: docker (running)",
+			},
+		},
+		{
+			name: "human format errored backend",
+			args: args{
+				outputType: "human",
+				status: prm.Status{
+					PuppetVersion: semver.MustParse("7.0.0"),
+					Backend:       prm.DOCKER,
+					BackendStatus: prm.BackendStatus{
+						IsAvailable: false,
+						StatusMsg:   "Descriptive error!",
+					},
+				},
+			},
+			matches: []string{
+				"> Puppet version: 7.0.0",
+				"> Backend: docker (error)",
+				"> Descriptive error!",
+			},
+		},
+		{
+			name: "json format running backend",
+			args: args{
+				outputType: "json",
+				status: prm.Status{
+					PuppetVersion: semver.MustParse("7.0.0"),
+					Backend:       prm.DOCKER,
+					BackendStatus: prm.BackendStatus{
+						IsAvailable: true,
+						StatusMsg:   "Running just fine",
+					},
+				},
+			},
+			matches: []string{
+				`"PuppetVersion":"7.0.0"`,
+				`"Backend":"docker"`,
+				`"IsAvailable":true`,
+			},
+		},
+		{
+			name: "json format errored backend",
+			args: args{
+				outputType: "json",
+				status: prm.Status{
+					PuppetVersion: semver.MustParse("7.0.0"),
+					Backend:       prm.DOCKER,
+					BackendStatus: prm.BackendStatus{
+						IsAvailable: false,
+						StatusMsg:   "Descriptive error!",
+					},
+				},
+			},
+			matches: []string{
+				`"PuppetVersion":"7.0.0"`,
+				`"Backend":"docker"`,
+				`"IsAvailable":false`,
+				`"StatusMsg":"Descriptive error!"`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotStatusMessage, err := prm.FormatStatus(tt.args.status, tt.args.outputType)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FormatStatus() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			for _, match := range tt.matches {
+				assert.Contains(t, gotStatusMessage, match)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR implements the status command. In this first pass, the logic for determining and formatting status lives in the status command package due to a cyclical dependency error caused by requiring a backend package from within the PRM package.

A future commit will need to resolve this cyclical dependency if the helper functions for status are to be moved out of the status command function as per standard design in the project. This will also be necessary for ensuring the exec and validate commands can be called without similarly needing to place the helper functions in their respective command packages.

This first pass does not yet include flags and should be updated to do so prior to any refactoring.
