### PR TITLE
(GH-61) Handle tool exit codes

### DIFF
--- a/pkg/prm/exec.go
+++ b/pkg/prm/exec.go
@@ -35,10 +35,13 @@ func (p *Prm) Exec(tool *Tool, args []string) error {
 		log.Info().Msgf("Tool %s/%s executed successfully", tool.Cfg.Plugin.Author, tool.Cfg.Plugin.Id)
 	case FAILURE:
 		log.Error().Msgf("Tool %s/%s failed to execute", tool.Cfg.Plugin.Author, tool.Cfg.Plugin.Id)
+		return err
 	case TOOL_ERROR:
 		log.Error().Msgf("Tool %s/%s encountered an error", tool.Cfg.Plugin.Author, tool.Cfg.Plugin.Id)
+		return err
 	case TOOL_NOT_FOUND:
 		log.Error().Msgf("Tool %s/%s not found", tool.Cfg.Plugin.Author, tool.Cfg.Plugin.Id)
+		return err
 	default:
 		log.Info().Msgf("Tool %s/%s exited with code %d", tool.Cfg.Plugin.Author, tool.Cfg.Plugin.Id, exit)
 	}


### PR DESCRIPTION
Surfaces the exit codes and errors raised by the tool within the container, up to the main application. This affects the exit status of the `exec` command.

![Screenshot 2021-12-10 082243](https://user-images.githubusercontent.com/1346683/145541529-0dd25dd5-8e64-4dca-992d-11b01a12a7fd.png)

![Screenshot 2021-12-10 082217](https://user-images.githubusercontent.com/1346683/145541543-42d9137e-ebb3-44ff-9e0f-4d71d29e31f2.png)

![Screenshot 2021-12-10 083221](https://user-images.githubusercontent.com/1346683/145542584-bc20c8a3-7008-46a1-af64-f2ebf7f65188.png)
