### PR TITLE
(GH-53) Leverage Afero instead of os/io directly

### DIFF
--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -82,9 +82,9 @@ func preExecute(cmd *cobra.Command, args []string) error {
 
 	switch prmApi.RunningConfig.Backend {
 	case prm.DOCKER:
-		prmApi.Backend = &prm.Docker{}
+		prmApi.Backend = &prm.Docker{AFS: prmApi.AFS, IOFS: prmApi.IOFS}
 	default:
-		prmApi.Backend = &prm.Docker{}
+		prmApi.Backend = &prm.Docker{AFS: prmApi.AFS, IOFS: prmApi.IOFS}
 	}
 
 	// handle the default cachepath

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -36,7 +36,7 @@ func CreateStatusCommand(parent *prm.Prm) *cobra.Command {
 func preExecute(cmd *cobra.Command, args []string) error {
 	switch prmApi.RunningConfig.Backend {
 	default:
-		prmApi.Backend = &prm.Docker{}
+		prmApi.Backend = &prm.Docker{AFS: prmApi.AFS, IOFS: prmApi.IOFS}
 	}
 	return nil
 }


### PR DESCRIPTION
Overview of PR:

- Removed usage of the os/io packages in the docker backend where
appropriate and replaced it with the Afero package while keeping it
functionally identical.