### PR TITLE
(GH-54) - Implement a timeout flag

### DIFF
--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -25,6 +25,7 @@ var (
 	prmApi      *prm.Prm
 	toolArgs    string
 	alwaysBuild bool
+	toolTimeout int
 )
 
 func CreateCommand(parent *prm.Prm) *cobra.Command {
@@ -77,6 +78,10 @@ func CreateCommand(parent *prm.Prm) *cobra.Command {
 	err = viper.BindPFlag("alwaysBuild", tmp.Flags().Lookup("alwaysBuild"))
 	cobra.CheckErr(err)
 
+	tmp.Flags().IntVar(&toolTimeout, "toolTimeout", 1800, "Time in seconds to wait for a response before exiting; defaults to 1800 (i.e. 30 minutes)")
+	err = viper.BindPFlag("toolTimeout", tmp.Flags().Lookup("toolTimeout"))
+	cobra.CheckErr(err)
+
 	return tmp
 }
 
@@ -87,9 +92,9 @@ func preExecute(cmd *cobra.Command, args []string) error {
 
 	switch prmApi.RunningConfig.Backend {
 	case prm.DOCKER:
-		prmApi.Backend = &prm.Docker{AFS: prmApi.AFS, IOFS: prmApi.IOFS, AlwaysBuild: alwaysBuild}
+		prmApi.Backend = &prm.Docker{AFS: prmApi.AFS, IOFS: prmApi.IOFS, AlwaysBuild: alwaysBuild, ContextTimeout: prmApi.RunningConfig.Timeout}
 	default:
-		prmApi.Backend = &prm.Docker{AFS: prmApi.AFS, IOFS: prmApi.IOFS, AlwaysBuild: alwaysBuild}
+		prmApi.Backend = &prm.Docker{AFS: prmApi.AFS, IOFS: prmApi.IOFS, AlwaysBuild: alwaysBuild, ContextTimeout: prmApi.RunningConfig.Timeout}
 	}
 
 	// handle the default cachepath

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -36,7 +36,7 @@ func CreateStatusCommand(parent *prm.Prm) *cobra.Command {
 func preExecute(cmd *cobra.Command, args []string) error {
 	switch prmApi.RunningConfig.Backend {
 	default:
-		prmApi.Backend = &prm.Docker{AFS: prmApi.AFS, IOFS: prmApi.IOFS}
+		prmApi.Backend = &prm.Docker{AFS: prmApi.AFS, IOFS: prmApi.IOFS, ContextTimeout: prmApi.RunningConfig.Timeout}
 	}
 	return nil
 }

--- a/pkg/prm/config.go
+++ b/pkg/prm/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/Masterminds/semver"
 	"github.com/rs/zerolog/log"
@@ -11,19 +12,22 @@ import (
 )
 
 const (
-	PuppetCmdFlag    string      = "puppet"
-	BackendCmdFlag   string      = "backend"
-	PuppetVerCfgKey  string      = "puppetversion" // Should match Config struct key.
-	BackendCfgKey    string      = "backend"       // Should match Config struct key.
-	DefaultPuppetVer string      = "7"
-	DefaultBackend   BackendType = DOCKER
-	ToolPathCfgKey   string      = "toolpath"
+	PuppetCmdFlag      string      = "puppet"
+	BackendCmdFlag     string      = "backend"
+	PuppetVerCfgKey    string      = "puppetversion" // Should match Config struct key.
+	BackendCfgKey      string      = "backend"       // Should match Config struct key.
+	DefaultPuppetVer   string      = "7"
+	DefaultBackend     BackendType = DOCKER
+	ToolPathCfgKey     string      = "toolpath"
+	ToolTimeoutCfgKey  string      = "toolTimeout"
+	DefaultToolTimeout int         = 1800 // 30 minutes
 )
 
 type Config struct {
 	PuppetVersion *semver.Version
 	Backend       BackendType
 	ToolPath      string
+	Timeout       time.Duration
 }
 
 func (p *Prm) GenerateDefaultCfg() {
@@ -44,6 +48,9 @@ func (p *Prm) GenerateDefaultCfg() {
 	}
 	log.Trace().Msgf("Setting default toolpath (%s: %s)", ToolPathCfgKey, defaultToolPath)
 	viper.SetDefault(ToolPathCfgKey, defaultToolPath)
+
+	log.Trace().Msgf("Setting default Timeout (%s: %d)", ToolTimeoutCfgKey, DefaultToolTimeout)
+	viper.SetDefault(ToolTimeoutCfgKey, DefaultToolTimeout)
 }
 
 func (p *Prm) LoadConfig() error {
@@ -65,6 +72,9 @@ func (p *Prm) LoadConfig() error {
 
 	// Load ToolPath from config
 	p.RunningConfig.ToolPath = viper.GetString(ToolPathCfgKey)
+
+	// Load Timeout from config
+	p.RunningConfig.Timeout = viper.GetDuration(ToolTimeoutCfgKey) * time.Second
 
 	return nil
 }

--- a/pkg/prm/docker.go
+++ b/pkg/prm/docker.go
@@ -26,12 +26,13 @@ import (
 
 type Docker struct {
 	// We need to be able to mock the docker client in testing
-	Client        DockerClientI
-	Context       context.Context
-	ContextCancel func()
-	AFS           *afero.Afero
-	IOFS          *afero.IOFS
-	AlwaysBuild   bool
+	Client         DockerClientI
+	Context        context.Context
+	ContextCancel  func()
+	ContextTimeout time.Duration
+	AFS            *afero.Afero
+	IOFS           *afero.IOFS
+	AlwaysBuild    bool
 }
 
 type DockerClientI interface {
@@ -363,7 +364,7 @@ func (d *Docker) initClient() (err error) {
 			return err
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+		ctx, cancel := context.WithTimeout(context.Background(), (d.ContextTimeout))
 
 		d.Client = cli
 		d.Context = ctx


### PR DESCRIPTION
Flag has been integrated into the prm config and possesses a default value.
Value of the flag is now passed through to `docker.go` where it is correctly implemented.
Acceptance test's added to prove that the timeout functions correctly.
`status.go` updated so that default timeout value is passed through, needed due to code shared between it and `exec.go`.