### PR TITLE
(MAINT) Ignore gosec warning

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -94,7 +94,8 @@ func InitConfig() {
 		cfgFilePath := filepath.Join(cfgPath, cfgFile)
 
 		if _, err := os.Stat(cfgFilePath); os.IsNotExist(err) {
-			if _, err := os.Create(cfgFilePath); err != nil {
+			_, err := os.Create(filepath.Clean(cfgFilePath))
+			if err != nil {
 				log.Error().Msgf("failed to initialise %s: %s", cfgFilePath, err)
 			}
 		}


### PR DESCRIPTION
Ignores a gosec warning about using a string variable to define a filepath for creating a file. The file to be created is the PRM config yaml and it's filepath needs to be defined in a variable.
