### PR TITLE
(MAINT) Ignore template dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 dist/
-# templates/
+tools/
 
 .DS_Store
 


### PR DESCRIPTION
This commit adds the template dir to gitignore so that goreleaser will build without error.