### PR TITLE
(GH-341) Update private `config_processor`

### DIFF
--- a/internal/pkg/config_processor/config_processor.go
+++ b/internal/pkg/config_processor/config_processor.go
@@ -29,6 +29,38 @@ func (p *ConfigProcessor) ProcessConfig(sourceDir, targetDir string, force bool)
 	return namespacedPath, nil
 }
 
+func (p *ConfigProcessor) CheckConfig(configFile string) error {
+	info, err := p.readConfig(configFile)
+	if err != nil {
+		return err
+	}
+
+	msg := fmt.Sprintf("The following attributes are missing in %s:\n", configFile)
+	orig := msg
+	// These parts are essential for build and deployment.
+
+	if info.Plugin.Id == "" {
+		msg = msg + "  * id\n"
+	}
+	if info.Plugin.Author == "" {
+		msg = msg + "  * author\n"
+	}
+	if info.Plugin.Version == "" {
+		msg = msg + "  * version\n"
+	}
+	if info.Plugin.UpstreamProjUrl == "" {
+		msg = msg + "  * upstream project url\n"
+	}
+	if info.Plugin.Display == "" {
+		msg = msg + "  * display name\n"
+	}
+	if msg != orig {
+		return fmt.Errorf(msg)
+	}
+
+	return nil
+}
+
 func (p *ConfigProcessor) readConfig(configFile string) (info prm.ToolConfigInfo, err error) {
 	fileBytes, err := p.AFS.ReadFile(configFile)
 	if err != nil {


### PR DESCRIPTION
Make the private `config_processor` package a valid implementation of the
`ConfigProcessorI` interface in `pdkgo/pkg/config_processor` by adding the
`CheckConfig()` function.