### PR TITLE
(GH-7) Add stubbed validate command

### DIFF
--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -1,0 +1,212 @@
+package validate
+
+import (
+	"fmt"
+	"os/user"
+	"path/filepath"
+	"strings"
+
+	"github.com/puppetlabs/prm/internal/pkg/utils"
+
+	"github.com/puppetlabs/pdkgo/pkg/telemetry"
+	"github.com/puppetlabs/prm/pkg/prm"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	localToolPath string
+	format        string
+	selectedTool  string
+	// selectedToolInfo    string
+	listTools   bool
+	prmApi      *prm.Prm
+	toolArgs    string
+	alwaysBuild bool
+	toolTimeout int
+)
+
+func CreateCommand(parent *prm.Prm) *cobra.Command {
+
+	prmApi = parent
+
+	tmp := &cobra.Command{
+		Use:               "validate <tool> [overrides|flags]",
+		Short:             "Validates Puppet Content with a given tool",
+		Long:              `Validates Puppet Content with a given tool`,
+		Args:              validateArgCount,
+		ValidArgsFunction: flagCompletion,
+		PreRunE:           preExecute,
+		RunE:              execute,
+	}
+
+	tmp.Flags().SortFlags = false
+
+	tmp.Flags().BoolVarP(&listTools, "list", "l", false, "list tools")
+	err := tmp.RegisterFlagCompletionFunc("list", flagCompletion)
+	cobra.CheckErr(err)
+
+	tmp.Flags().StringVar(&format, "format", "table", "display output in human-readable or json format")
+	err = tmp.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		var formats = []string{"table", "json"}
+		return utils.Find(formats, toComplete), cobra.ShellCompDirectiveNoSpace | cobra.ShellCompDirectiveNoFileComp
+	})
+	cobra.CheckErr(err)
+
+	tmp.Flags().StringVar(&localToolPath, "toolpath", "", "location of installed tools")
+	err = viper.BindPFlag("toolpath", tmp.Flags().Lookup("toolpath"))
+	cobra.CheckErr(err)
+
+	tmp.Flags().StringVar(&prmApi.CodeDir, "codedir", "", "location of code to execute against")
+	err = viper.BindPFlag("codedir", tmp.Flags().Lookup("codedir"))
+	cobra.CheckErr(err)
+
+	tmp.Flags().StringVar(&prmApi.CacheDir, "cachedir", "", "location of cache used by PRM")
+	err = viper.BindPFlag("cachedir", tmp.Flags().Lookup("cachedir"))
+	cobra.CheckErr(err)
+
+	tmp.Flags().StringVar(&toolArgs, "toolArgs", "", "Additional arguments to pass to the tool")
+	err = viper.BindPFlag("toolArgs", tmp.Flags().Lookup("toolArgs"))
+	cobra.CheckErr(err)
+
+	tmp.Flags().BoolVarP(&alwaysBuild, "alwaysBuild", "a", false, "Rebuild the docker image for each tool execution, even if it already exists")
+	err = viper.BindPFlag("alwaysBuild", tmp.Flags().Lookup("alwaysBuild"))
+	cobra.CheckErr(err)
+
+	tmp.Flags().IntVar(&toolTimeout, "toolTimeout", 1800, "Time in seconds to wait for a response before exiting; defaults to 1800 (i.e. 30 minutes)")
+	err = viper.BindPFlag("toolTimeout", tmp.Flags().Lookup("toolTimeout"))
+	cobra.CheckErr(err)
+
+	return tmp
+}
+
+func preExecute(cmd *cobra.Command, args []string) error {
+	if localToolPath == "" {
+		localToolPath = prmApi.RunningConfig.ToolPath
+	}
+
+	switch prmApi.RunningConfig.Backend {
+	case prm.DOCKER:
+		prmApi.Backend = &prm.Docker{AFS: prmApi.AFS, IOFS: prmApi.IOFS, AlwaysBuild: alwaysBuild, ContextTimeout: prmApi.RunningConfig.Timeout}
+	default:
+		prmApi.Backend = &prm.Docker{AFS: prmApi.AFS, IOFS: prmApi.IOFS, AlwaysBuild: alwaysBuild, ContextTimeout: prmApi.RunningConfig.Timeout}
+	}
+
+	// handle the default cachepath
+	if prmApi.CacheDir == "" {
+		usr, _ := user.Current()
+		dir := usr.HomeDir
+		prmApi.CacheDir = filepath.Join(dir, ".pdk/prm/cache")
+	}
+
+	prmApi.List(localToolPath, "")
+	return nil
+}
+
+func validateArgCount(cmd *cobra.Command, args []string) error {
+	if len(args) >= 1 {
+		if len(strings.Split(args[0], "/")) != 2 {
+			return fmt.Errorf("Selected tool must be in AUTHOR/ID format")
+		}
+		selectedTool = args[0]
+	}
+
+	return nil
+}
+
+func flagCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if localToolPath == "" {
+		err := preExecute(cmd, args)
+		if err != nil {
+			log.Error().Msgf("Unable to set tool path: %s", err.Error())
+			return nil, cobra.ShellCompDirectiveError
+		}
+	}
+	if len(args) != 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	localToolPath = viper.GetString(prm.ToolPathCfgKey)
+
+	return completeName(localToolPath, toComplete), cobra.ShellCompDirectiveNoSpace | cobra.ShellCompDirectiveNoFileComp
+}
+
+func completeName(cache string, match string) []string {
+	var names []string
+	for toolName, tool := range prmApi.Cache {
+		if strings.HasPrefix(toolName, match) {
+			m := toolName + "\t" + tool.Cfg.Plugin.Display
+			names = append(names, m)
+		}
+	}
+	return names
+}
+
+func execute(cmd *cobra.Command, args []string) error {
+	span := telemetry.GetSpanFromContext(cmd.Context())
+	// Add tool to span if needed
+	if len(args) == 1 {
+		telemetry.AddStringSpanAttribute(span, "tool", args[0])
+	}
+
+	log.Trace().Msg("Validate")
+	log.Trace().Msgf("Tool path: %v", localToolPath)
+	log.Trace().Msgf("Selected Tool: %v", selectedTool)
+
+	if listTools {
+		formattedTemplates, err := prmApi.FormatTools(prmApi.Cache, format)
+		if err != nil {
+			return err
+		}
+		fmt.Print(formattedTemplates)
+
+		return nil
+	}
+
+	// var additionalToolArgs []string
+	// if toolArgs != "" {
+	// 	additionalToolArgs, _ = shlex.Split(toolArgs)
+	// }
+
+	if selectedTool != "" {
+		// get the tool from the cache
+		// cachedTool, ok := prmApi.IsToolAvailable(selectedTool)
+		_, ok := prmApi.IsToolAvailable(selectedTool)
+		if !ok {
+			return fmt.Errorf("Tool %s not found in cache", selectedTool)
+		}
+		// execute!
+		// err := prmApi.Exec(cachedTool, additionalToolArgs)
+		// if err != nil {
+		// 	return err
+		// }
+	}
+	// Uncomment when implementing validate.yml
+	// else {
+	// 	// No tool specified, so check if their code contains a validate.yml, which returns the list of tools
+	// 	// Their code is expected to be in the directory where the executable is run from
+	// 	toolList, err := prmApi.CheckLocalConfig()
+	// 	if err != nil {
+	// 		return err
+	// 	}
+
+	// 	log.Info().Msgf("Found tools: %v ", toolList)
+
+	// 	for _, tool := range toolList {
+	// 		cachedTool, ok := prmApi.IsToolAvailable(tool.Name)
+	// 		if !ok {
+	// 			return fmt.Errorf("Tool %s not found in cache", tool)
+	// 		}
+
+	// 		err := prmApi.Exec(cachedTool, tool.Args)
+	// 		if err != nil {
+	// 			return err
+	// 		}
+	// 	}
+	// }
+
+	return nil
+}

--- a/cmd/validate/validate_test.go
+++ b/cmd/validate/validate_test.go
@@ -1,0 +1,91 @@
+package validate_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"regexp"
+	"testing"
+
+	"github.com/puppetlabs/prm/cmd/exec"
+	"github.com/puppetlabs/prm/pkg/prm"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func nullFunction(cmd *cobra.Command, args []string) error {
+	return nil
+}
+
+func TestCreateCommand(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		returnCode int
+		out        string
+		wantCmd    *cobra.Command
+		wantErr    bool
+		f          func(cmd *cobra.Command, args []string) error
+	}{
+		{
+			name:    "executes without error",
+			f:       nullFunction,
+			out:     "",
+			wantErr: false,
+		},
+		{
+			name:    "executes without error for valid flag",
+			args:    []string{"author/templateId"},
+			f:       nullFunction,
+			out:     "",
+			wantErr: false,
+		},
+		{
+			name:    "executes with error when tool provided in the wrong format",
+			args:    []string{"foo-bar"},
+			f:       nullFunction,
+			out:     "Selected tool must be in AUTHOR/ID format",
+			wantErr: true,
+		},
+		{
+			name:    "executes with error for invalid flag",
+			args:    []string{"--foo"},
+			f:       nullFunction,
+			out:     "unknown flag: --foo",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			prmObj := &prm.Prm{
+				AFS:  &afero.Afero{Fs: fs},
+				IOFS: &afero.IOFS{Fs: fs},
+			}
+			cmd := exec.CreateCommand(prmObj)
+			b := bytes.NewBufferString("")
+			cmd.SetOut(b)
+			cmd.SetErr(b)
+			cmd.SetArgs(tt.args)
+			cmd.RunE = tt.f
+
+			err := cmd.Execute()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("executeTestUnit() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			out, err := ioutil.ReadAll(b)
+			if err != nil {
+				t.Errorf("Failed to read stdout: %v", err)
+				return
+			}
+
+			output := string(out)
+			r := regexp.MustCompile(tt.out)
+			if !r.MatchString(output) {
+				t.Errorf("output did not match regexp /%s/\n> output\n%s\n", r, output)
+				return
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/puppetlabs/prm/cmd/root"
 	"github.com/puppetlabs/prm/cmd/set"
 	"github.com/puppetlabs/prm/cmd/status"
+	"github.com/puppetlabs/prm/cmd/validate"
 	appver "github.com/puppetlabs/prm/cmd/version"
 	"github.com/puppetlabs/prm/internal/pkg/config_processor"
 	"github.com/puppetlabs/prm/pkg/prm"
@@ -70,6 +71,9 @@ func main() {
 
 	// exec command
 	rootCmd.AddCommand(exec.CreateCommand(prmApi))
+
+	// validate command
+	rootCmd.AddCommand(validate.CreateCommand(prmApi))
 
 	// status command
 	rootCmd.AddCommand(status.CreateStatusCommand(prmApi))


### PR DESCRIPTION
This PR adds the validate command to the app. In this initial implementation it does not run any tools. It can list available tools but does not filter for validators only. If a tool is specified it will check to see if the tool is available.

Future work will be required to wire this up for validation functionality. This PR leaves commented code borrowed from the implementation of exec which may be useful, but must be addressed prior to release.

Resolves #7