### PR TITLE
(GH-125) Ensure validate list only returns validators

### DIFF
--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -104,7 +104,7 @@ func preExecute(cmd *cobra.Command, args []string) error {
 		prmApi.CacheDir = filepath.Join(dir, ".pdk/prm/cache")
 	}
 
-	prmApi.List(localToolPath, "")
+	prmApi.List(localToolPath, "", false)
 	return nil
 }
 

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -103,7 +103,7 @@ func preExecute(cmd *cobra.Command, args []string) error {
 		prmApi.CacheDir = filepath.Join(dir, ".pdk/prm/cache")
 	}
 
-	prmApi.List(localToolPath, "")
+	prmApi.List(localToolPath, "", true)
 	return nil
 }
 

--- a/pkg/prm/prm.go
+++ b/pkg/prm/prm.go
@@ -153,7 +153,7 @@ func (p *Prm) readToolConfig(configFile string) Tool {
 // List lists all templates in a given path and parses their configuration. Does
 // not return any errors from parsing invalid templates, but returns them as
 // debug log events
-func (p *Prm) List(toolPath string, toolName string) {
+func (p *Prm) List(toolPath string, toolName string, onlyValidators bool) {
 	log.Debug().Msgf("Searching %+v for tool configs", toolPath)
 	// Triple glob to match author/id/version/ToolConfigFileName
 	matches, _ := p.IOFS.Glob(toolPath + "/**/**/**/" + ToolConfigFileName)
@@ -163,6 +163,10 @@ func (p *Prm) List(toolPath string, toolName string) {
 		log.Debug().Msgf("Found: %+v", file)
 		i := p.readToolConfig(file)
 		if i.Cfg.Plugin != nil {
+			if onlyValidators && !i.Cfg.Common.CanValidate {
+				log.Debug().Msgf("Not a validator: %+v", file)
+				continue
+			}
 			i.Cfg.Path = filepath.Dir(file)
 			tmpls = append(tmpls, i.Cfg)
 		}


### PR DESCRIPTION
Prior to this PR, the validate command always returned the full list
of available tools, even those which are not validators. The logic for
listing tools was shared between the exec and validate commands.

This PR extends `prm.List()` to take an additional parameter,
`onlyValidators` as a boolean. If `onlyValidators` is passed as true,
skip caching any tools which are not validators.

This PR updates the references to `prm.List()` to pass false for
`onlyValidators` in the exec command and to pass true in the validate
command. This ensures that exec returns the full list of tools and
validate only returns validators.

Resolves #125