### PR TITLE
(GH-127) Minimally implement docker validate

### DIFF
--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -166,23 +166,17 @@ func execute(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// var additionalToolArgs []string
-	// if toolArgs != "" {
-	// 	additionalToolArgs, _ = shlex.Split(toolArgs)
-	// }
-
 	if selectedTool != "" {
 		// get the tool from the cache
-		// cachedTool, ok := prmApi.IsToolAvailable(selectedTool)
-		_, ok := prmApi.IsToolAvailable(selectedTool)
+		cachedTool, ok := prmApi.IsToolAvailable(selectedTool)
 		if !ok {
 			return fmt.Errorf("Tool %s not found in cache", selectedTool)
 		}
 		// execute!
-		// err := prmApi.Exec(cachedTool, additionalToolArgs)
-		// if err != nil {
-		// 	return err
-		// }
+		err := prmApi.Validate(cachedTool)
+		if err != nil {
+			return err
+		}
 	}
 	// Uncomment when implementing validate.yml
 	// else {

--- a/internal/pkg/mock/backend.go
+++ b/internal/pkg/mock/backend.go
@@ -11,6 +11,7 @@ type MockBackend struct {
 	StatusMessageString string
 	ToolAvalible        bool
 	ExecReturn          string
+	ValidateReturn      string
 }
 
 func (m *MockBackend) Status() prm.BackendStatus {
@@ -26,8 +27,17 @@ func (m *MockBackend) GetTool(tool *prm.Tool, prmConfig prm.Config) error {
 }
 
 // Implement when needed
-func (m *MockBackend) Validate(tool *prm.Tool) (prm.ToolExitCode, error) {
-	return prm.FAILURE, nil
+func (m *MockBackend) Validate(tool *prm.Tool, prmConfig prm.Config, paths prm.DirectoryPaths) (prm.ValidateExitCode, error) {
+	switch m.ExecReturn {
+	case "PASS":
+		return prm.VALIDATION_PASS, nil
+	case "FAIL":
+		return prm.VALIDATION_FAILED, errors.New("VALIDATION FAIL")
+	case "ERROR":
+		return prm.VALIDATION_ERROR, errors.New("DOCKER ERROR")
+	default:
+		return prm.VALIDATION_ERROR, errors.New("DOCKER FAIL")
+	}
 }
 
 func (m *MockBackend) Exec(tool *prm.Tool, args []string, prmConfig prm.Config, paths prm.DirectoryPaths) (prm.ToolExitCode, error) {

--- a/pkg/prm/backend.go
+++ b/pkg/prm/backend.go
@@ -9,7 +9,7 @@ const (
 
 type BackendI interface {
 	GetTool(tool *Tool, prmConfig Config) error
-	Validate(tool *Tool) (ToolExitCode, error)
+	Validate(tool *Tool, prmConfig Config, paths DirectoryPaths) (ValidateExitCode, error)
 	Exec(tool *Tool, args []string, prmConfig Config, paths DirectoryPaths) (ToolExitCode, error)
 	Status() BackendStatus
 }

--- a/pkg/prm/validate_test.go
+++ b/pkg/prm/validate_test.go
@@ -1,0 +1,100 @@
+package prm_test
+
+import (
+	"testing"
+
+	"github.com/puppetlabs/pdkgo/pkg/install"
+	"github.com/puppetlabs/prm/internal/pkg/mock"
+	"github.com/puppetlabs/prm/pkg/prm"
+	"github.com/spf13/afero"
+)
+
+func TestPrm_Validate(t *testing.T) {
+	type fields struct {
+		RunningConfig prm.Config
+		CodeDir       string
+		CacheDir      string
+		Cache         map[string]*prm.Tool
+		Backend       prm.BackendI
+	}
+	type args struct {
+		id               string
+		validateReturn   string // Could this not just be the actual enum?
+		expectedErrMsg   string
+		toolNotAvailable bool
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Content passes validation",
+			args: args{
+				id:             "pass",
+				validateReturn: "PASS",
+			},
+		},
+		{
+			name: "Content fails validation",
+			args: args{
+				id:             "fail",
+				validateReturn: "FAIL",
+				expectedErrMsg: "VALIDATION FAIL",
+			},
+		},
+		{
+			name: "Tool errors during validation",
+			args: args{
+				id:             "error",
+				validateReturn: "ERROR",
+				expectedErrMsg: "DOCKER ERROR",
+			},
+		},
+		{
+			name: "Fails to get tool",
+			args: args{
+				id:               "tool-get-fail",
+				expectedErrMsg:   "Tool Not Found",
+				toolNotAvailable: true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			afs := &afero.Afero{Fs: fs}
+			iofs := &afero.IOFS{Fs: fs}
+
+			tool := &prm.Tool{
+				Cfg: prm.ToolConfig{
+					Plugin: &prm.PluginConfig{
+						ConfigParams: install.ConfigParams{
+							Id:      tt.args.id,
+							Author:  "puppetlabs",
+							Version: "0.1.0",
+						},
+					},
+				},
+			}
+
+			p := &prm.Prm{
+				AFS:           afs,
+				IOFS:          iofs,
+				RunningConfig: tt.fields.RunningConfig,
+				CodeDir:       tt.fields.CodeDir,
+				CacheDir:      tt.fields.CacheDir,
+				Cache:         tt.fields.Cache,
+				Backend: &mock.MockBackend{
+					ToolAvalible: !tt.args.toolNotAvailable,
+					ExecReturn:   tt.args.validateReturn,
+				},
+			}
+
+			if err := p.Validate(tool); err != nil && err.Error() != tt.args.expectedErrMsg {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR minimally implements the `prm validate` command for the docker
backend.

This PR adds unit tests for the `pkg/prm/validate.go` and
`cmd/validate/validate.go` files and for the `validate()`
function, in the `pkg/prm/docker.go` file. Mock files have
been modified appropriately to facilitate these unit tests.

This PR resolves issue #127.