### PR TITLE
(MAINT) Fix docker fix docker logs

### DIFF
--- a/pkg/prm/docker.go
+++ b/pkg/prm/docker.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -322,11 +321,6 @@ func (d *Docker) Validate(tool *Tool, prmConfig Config, paths DirectoryPaths, ou
 		}
 
 		if outputSettings.OutputLocation == "file" {
-			bytes, err := ioutil.ReadAll(out)
-			if err != nil {
-				return VALIDATION_ERROR, err
-			}
-
 			if _, err := os.Stat(outputSettings.OutputDir); os.IsNotExist(err) {
 				err = d.AFS.Mkdir(outputSettings.OutputDir, 0750)
 				if err != nil {
@@ -346,7 +340,7 @@ func (d *Docker) Validate(tool *Tool, prmConfig Config, paths DirectoryPaths, ou
 				return VALIDATION_ERROR, err
 			}
 
-			_, err = file.WriteString(fmt.Sprintf("%s", string(bytes[:])))
+			_, err = stdcopy.StdCopy(file, file, out)
 			if err != nil {
 				return VALIDATION_ERROR, err
 			}


### PR DESCRIPTION
Prior to this commit we were seeing strange behaviour when extracting
logs from a container. The log files written seemed to have unexpected
encoding. It turns out this is because the output of ContainerLogs()
returns a multiplexed stream of the container's stdout and stderr.
Therefore we need to demultiplex the stream before we can decode the
logs and write to our log file.

This commit updates the validate code to use the stdcopy package
provided by the docker sdk to demultiplex the stream.

For reference, see the docs:
https://pkg.go.dev/github.com/moby/moby/client#Client.ContainerLogs

<!--
Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/prm/blob/main/CONTRIBUTING.md

and

CODE_OF_CONDUCT - https://github.com/puppetlabs/prm/blob/main/CODE_OF_CONDUCT.md

Submitting a Pull Request:

- Create a fork of this repo in Github
- Create a new branch `git checkout -b my-branch-name`
- Make you change, add tests, and ensure tests pass
- Do not reformat existing code, it makes it hard to see what has changed. Leave the formatting to us.
- Make sure your commit messages are in the proper format. If the commit addresses an issue filed in the project, start the first line of the commit with the prefix `GH-` and the issue number in parentheses `(GH-111)`. Then leave a detailed explanation of your change, so a person in the future can understand what your work does.
- Update the `Unreleased` section in the CHANGELOG.md with your change

THANKS!
-->
