### PR TITLE
(GH-129) Tool output handling

### DIFF
--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -2,7 +2,9 @@ package validate
 
 import (
 	"fmt"
+	"os"
 	"os/user"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -25,6 +27,7 @@ var (
 	toolArgs    string
 	alwaysBuild bool
 	toolTimeout int
+	resultsView string
 )
 
 func CreateCommand(parent *prm.Prm) *cobra.Command {
@@ -81,12 +84,20 @@ func CreateCommand(parent *prm.Prm) *cobra.Command {
 	err = viper.BindPFlag("toolTimeout", tmp.Flags().Lookup("toolTimeout"))
 	cobra.CheckErr(err)
 
+	tmp.Flags().StringVar(&resultsView, "resultsView", "terminal", "Controls where results are outputted to, either 'terminal' or 'file' (Defaults: single tool = 'terminal', multiple tools = 'file')")
+	err = viper.BindPFlag("resultsView", tmp.Flags().Lookup("resultsView"))
+	cobra.CheckErr(err)
+
 	return tmp
 }
 
 func preExecute(cmd *cobra.Command, args []string) error {
 	if localToolPath == "" {
 		localToolPath = prmApi.RunningConfig.ToolPath
+	}
+
+	if resultsView != "terminal" && resultsView != "file" {
+		return fmt.Errorf("The --resultsView flag must be set to either [terminal|file]")
 	}
 
 	switch prmApi.RunningConfig.Backend {
@@ -172,8 +183,14 @@ func execute(cmd *cobra.Command, args []string) error {
 		if !ok {
 			return fmt.Errorf("Tool %s not found in cache", selectedTool)
 		}
-		// execute!
-		err := prmApi.Validate(cachedTool)
+
+		workingDir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		log.Debug().Msgf("Working Directory: %v", workingDir)
+		err = prmApi.Validate(cachedTool, prm.OutputSettings{OutputLocation: resultsView, OutputDir: path.Join(workingDir, ".prm-validate")})
 		if err != nil {
 			return err
 		}

--- a/cmd/validate/validate_test.go
+++ b/cmd/validate/validate_test.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/puppetlabs/prm/cmd/exec"
+	"github.com/puppetlabs/prm/cmd/validate"
 	"github.com/puppetlabs/prm/pkg/prm"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -61,7 +61,7 @@ func TestCreateCommand(t *testing.T) {
 				AFS:  &afero.Afero{Fs: fs},
 				IOFS: &afero.IOFS{Fs: fs},
 			}
-			cmd := exec.CreateCommand(prmObj)
+			cmd := validate.CreateCommand(prmObj)
 			b := bytes.NewBufferString("")
 			cmd.SetOut(b)
 			cmd.SetErr(b)

--- a/internal/pkg/mock/backend.go
+++ b/internal/pkg/mock/backend.go
@@ -27,7 +27,7 @@ func (m *MockBackend) GetTool(tool *prm.Tool, prmConfig prm.Config) error {
 }
 
 // Implement when needed
-func (m *MockBackend) Validate(tool *prm.Tool, prmConfig prm.Config, paths prm.DirectoryPaths) (prm.ValidateExitCode, error) {
+func (m *MockBackend) Validate(tool *prm.Tool, prmConfig prm.Config, paths prm.DirectoryPaths, outputSettings prm.OutputSettings) (prm.ValidateExitCode, error) {
 	switch m.ExecReturn {
 	case "PASS":
 		return prm.VALIDATION_PASS, nil

--- a/internal/pkg/mock/docker.go
+++ b/internal/pkg/mock/docker.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/pkg/stdcopy"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/puppetlabs/prm/pkg/prm"
-	"io"
 )
 
 type DockerClient struct {

--- a/pkg/prm/backend.go
+++ b/pkg/prm/backend.go
@@ -9,7 +9,7 @@ const (
 
 type BackendI interface {
 	GetTool(tool *Tool, prmConfig Config) error
-	Validate(tool *Tool, prmConfig Config, paths DirectoryPaths) (ValidateExitCode, error)
+	Validate(tool *Tool, prmConfig Config, paths DirectoryPaths, outputSettings OutputSettings) (ValidateExitCode, error)
 	Exec(tool *Tool, args []string, prmConfig Config, paths DirectoryPaths) (ToolExitCode, error)
 	Status() BackendStatus
 }
@@ -25,4 +25,9 @@ type BackendStatus struct {
 type DirectoryPaths struct {
 	codeDir  string
 	cacheDir string
+}
+
+type OutputSettings struct {
+	OutputLocation string // Either "terminal" or "file"
+	OutputDir      string // Directory to write log file to
 }

--- a/pkg/prm/validate.go
+++ b/pkg/prm/validate.go
@@ -17,7 +17,7 @@ const (
 // Tools can be empty, in which case we expect that a local
 // configuration file (validate.yml) will contain a list of
 // tools to run.
-func (p *Prm) Validate(tool *Tool) error {
+func (p *Prm) Validate(tool *Tool, outputSettings OutputSettings) error {
 
 	// is the tool available?
 	err := p.Backend.GetTool(tool, p.RunningConfig)
@@ -27,18 +27,18 @@ func (p *Prm) Validate(tool *Tool) error {
 	}
 
 	// the tool is available so execute against it
-	exit, err := p.Backend.Validate(tool, p.RunningConfig, DirectoryPaths{codeDir: p.CodeDir, cacheDir: p.CacheDir})
+	exit, err := p.Backend.Validate(tool, p.RunningConfig, DirectoryPaths{codeDir: p.CodeDir, cacheDir: p.CacheDir}, outputSettings)
 
 	switch exit {
 	case VALIDATION_PASS:
 		log.Info().Msgf("Tool %s/%s validated successfully", tool.Cfg.Plugin.Author, tool.Cfg.Plugin.Id)
-		return err
+		log.Info().Msg("PASS")
 	case VALIDATION_FAILED:
 		log.Error().Msgf("Tool %s/%s validation returned at least one failure", tool.Cfg.Plugin.Author, tool.Cfg.Plugin.Id)
-		return err
+		log.Error().Msg("FAIL")
 	case VALIDATION_ERROR:
 		log.Error().Msgf("Tool %s/%s encountered errored during validation %s", tool.Cfg.Plugin.Author, tool.Cfg.Plugin.Id, err)
-		return err
+		log.Error().Msg("ERROR")
 	default:
 		log.Info().Msgf("Tool %s/%s exited with code %d", tool.Cfg.Plugin.Author, tool.Cfg.Plugin.Id, exit)
 	}

--- a/pkg/prm/validate_test.go
+++ b/pkg/prm/validate_test.go
@@ -22,6 +22,7 @@ func TestPrm_Validate(t *testing.T) {
 		validateReturn   string // Could this not just be the actual enum?
 		expectedErrMsg   string
 		toolNotAvailable bool
+		outputSettings   prm.OutputSettings
 	}
 	tests := []struct {
 		name    string
@@ -92,7 +93,7 @@ func TestPrm_Validate(t *testing.T) {
 				},
 			}
 
-			if err := p.Validate(tool); err != nil && err.Error() != tt.args.expectedErrMsg {
+			if err := p.Validate(tool, tt.args.outputSettings); err != nil && err.Error() != tt.args.expectedErrMsg {
 				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
In this PR:

- PASS or FAIL is logged after a tool validates, depending on what code the tool exits with.
- Added a flag `--resultsView` which allows for the container logs of a docker container to either be outputted to the terminal or a file. By default for single tools, results will be outputted to the terminal.
- Added unit tests for outputting container logs to a file.
- Fixed previous unit tests for the validate command.